### PR TITLE
Devbox Setup with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Items that don't need to be in a Docker image.
+# Anything not used by the build system should go here.
+Dockerfile
+.dockerignore
+.gitignore
+README.md
+
+# Artifacts that will be built during image creation.
+# This should contain all files created during `npm run build`.
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:latest
+MAINTAINER Rafael Ballestiero <rafa.ballestiero@gmail.com>
+
+# Prepare app directory
+RUN mkdir -p /app
+COPY . /app
+
+# Install dependencies
+WORKDIR /app
+RUN npm run setup
+
+# Build the app
+RUN npm run build
+
+# Expose the app port
+EXPOSE 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+web:
+  build: .
+  ports:
+    - "8080:8080"
+  volumes:
+    - .:/app
+  environment:
+    - NODE_ENV=dev
+  command: npm run dev

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
   "description": "React implementation of the http://etheroscope.alice.si",
   "main": "index.js",
   "scripts": {
-    "dev": "webpack-dev-server --inline --content-base ./ --env.dev",
+    "dev": "webpack-dev-server --host 0.0.0.0 --port 8080 --inline --content-base ./ --env.dev",
     "build": "webpack --env.prod",
     "test": "cross-env NODE_ENV=test nyc mocha",
     "watch:test": "mocha --watch --compilers js:babel-register",
     "start": "http-server",
     "vm-start": "forever start",
+    "clean": "npm prune && npm dedupe",
     "setup": "npm install"
   },
   "repository": {
@@ -34,7 +35,8 @@
     "react-router": "2.6.1",
     "react-router-dom": "^4.2.2",
     "react-tooltip": "3.1.5",
-    "styled-components": "^2.2.1"
+    "styled-components": "^2.2.1",
+    "webpacker": "0.0.3"
   },
   "devDependencies": {
     "babel-core": "6.13.2",


### PR DESCRIPTION
**What?**

Added Docker code needed to run webpack-dev-server in a docker container. This still supports hot code reload.

**Why?**

Needed for use with devbox repo to standardize development and make setup hassle-free. Also, super cool.

**What now?**

We could use these docker containers in production as well to simplify the deployment process and streamline the continuous delivery pipeline.