### PR TITLE
favourite contracts in explorer drop down

### DIFF
--- a/app/scenes/Etheroscope/components/Favourites.js
+++ b/app/scenes/Etheroscope/components/Favourites.js
@@ -65,7 +65,7 @@ export default class Favourites extends React.Component {
             {fav.name}
             <FavouriteDropDown> 
             {fav.contracts.map(c => (
-              <FavouriteContract onClick={() => this.props.handleClick(contract)}>{c}</FavouriteContract>))}
+              <FavouriteContract onClick={() => window.location='/contracts/' + c.address}>{c.address}</FavouriteContract>))}
             </FavouriteDropDown>
           </FavouriteName>)
         )

--- a/app/scenes/Etheroscope/components/Favourites.js
+++ b/app/scenes/Etheroscope/components/Favourites.js
@@ -4,26 +4,70 @@ import styled from 'styled-components'
 export default class Favourites extends React.Component {
 
   render() {
+    const FavouritesLabel = styled.span`
+      color: #f9f9f9;
+      font-size: 20px;
+      font-weight: 600;
+      margin-right: 30px;
+    `
+    
     const Section = styled.section`
       margin-bottom: 15px;
     `
-    const FavouriteLink = styled.a`
-      color: #f9f9f9;
+    
+    const FavouriteDropDown = styled.div`
+      display: none;
+      position: absolute;
+      background: #f9f9f9;
+      list-style: none;
+      flex-wrap: wrap;
+      border-radius: 3px;
+      margin-top: 9px;
+      margin-left: -15px;
+    `
+    
+    const FavouriteName = styled.button`
+      color: #4B6575;
       margin-right: 10px;
       border-bottom: white 1px solid;
       text-decoration: none;
       cursor: pointer;
+      padding: 8px 16px;
+      background: #f9f9f9;
+      font-weight: 600;
+      border-radius: 3px;
+      &:hover {
+        cursor: default;
+      };
+      &:hover ${FavouriteDropDown} {
+        display: block;
+      }
+    `
+    
+    const FavouriteContract = styled.li`
+      color: #4B6575;
+      margin-right: 10px;
+      border-bottom: white 1px solid;
+      text-decoration: none;
+      cursor: pointer;
+      padding: 8px 16px;
+      background: #f9f9f9;
+      font-weight: 600;
+      border-radius: 3px;
     `
 
     const favourites = JSON.parse(localStorage.favourites || '[]')
-
     return (
       <Section>
-        <span>Favourites: </span>
+        <FavouritesLabel>Favourites: </FavouritesLabel>
         {favourites.map(fav => fav.contracts.map(contract =>
-          (<FavouriteLink key={contract} onClick={() => this.props.handleClick(contract)}>
+          (<FavouriteName key={contract}>
             {fav.name}
-          </FavouriteLink>)
+            <FavouriteDropDown> 
+            {fav.contracts.map(c => (
+              <FavouriteContract onClick={() => this.props.handleClick(contract)}>{c}</FavouriteContract>))}
+            </FavouriteDropDown>
+          </FavouriteName>)
         )
         )}
       </Section>

--- a/app/scenes/Etheroscope/index.js
+++ b/app/scenes/Etheroscope/index.js
@@ -12,6 +12,7 @@ const Wrapper = styled.div`
 const BodyWrapper = styled.div`
   padding: 132px 0 20px 0;
   background-color: #efefef;
+  min-height: 70vh;
 `
 
 class EtheroscopeContainer extends React.Component {


### PR DESCRIPTION
# What?
Contract explorer - favourites display names of orgs, each with a drop down showing each contract for that org.

# Why?
So users can access all favourited contracts