### PR TITLE
Fixed variable layout overflowing

### DIFF
--- a/app/scenes/Etheroscope/components/VariableSelection.js
+++ b/app/scenes/Etheroscope/components/VariableSelection.js
@@ -26,7 +26,8 @@ const VarSelectedButton = styled.button`
 const Separator = styled.hr`
 `
 const VarContainer = styled.div`
-    display: inline-flex;
+    display: flex;
+    flex-wrap: wrap;
     align-items: center;
     width: auto;
     min-width: 160px;


### PR DESCRIPTION
On the contract viewer, the list of variables would overflow its container. This commit fixes that